### PR TITLE
add parent category to accounting tracking category model; fix setup.py

### DIFF
--- a/MergePythonSDK/accounting/model/tracking_category.py
+++ b/MergePythonSDK/accounting/model/tracking_category.py
@@ -105,6 +105,7 @@ class TrackingCategory(ModelNormal):
             'name': (str, none_type, none_type,),  # noqa: E501
             'status': (Status7d1Enum, str, none_type,),
             'category_type': (CategoryTypeEnum, str, none_type,),
+            'parent_category': (str, none_type,),  # noqa: E501
             'remote_was_deleted': (bool, none_type,),  # noqa: E501
         }
         return defined_types
@@ -121,6 +122,7 @@ class TrackingCategory(ModelNormal):
         'name': 'name',  # noqa: E501
         'status': 'status',  # noqa: E501
         'category_type': 'category_type',  # noqa: E501
+        'parent_category': 'parent_category',  # noqa: E501
         'remote_was_deleted': 'remote_was_deleted',  # noqa: E501
     }
 
@@ -211,6 +213,7 @@ class TrackingCategory(ModelNormal):
         self.name = kwargs.get("name", None)
         self.status = kwargs.get("status", None)
         self.category_type = kwargs.get("category_type", None)
+        self.parent_category = kwargs.get("parent_category", None)
 
         # Read only properties
         self._id = kwargs.get("id", str())
@@ -302,6 +305,7 @@ class TrackingCategory(ModelNormal):
         self.name: Union[str, none_type] = kwargs.get("name", None)
         self.status: Union[bool, dict, float, int, list, str, none_type] = kwargs.get("status", None)
         self.category_type: Union[bool, dict, float, int, list, str, none_type] = kwargs.get("category_type", None)
+        self.parent_category: Union[str, none_type] = kwargs.get("parent_category", None)
 
         # Read only properties
         self._id: Union[str] = kwargs.get("id", str())

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """
-    Merge Ticketing API
+    Merge Unified API
 
-    The unified API for building rich integrations with multiple Ticketing platforms.  # noqa: E501
+    The unified API for building rich integrations with multiple integration platforms.  # noqa: E501
 
     The version of the OpenAPI document: 1.0
     Contact: hello@merge.dev
@@ -11,7 +11,7 @@
 
 from setuptools import setup, find_packages  # noqa: H301
 
-NAME = "MergePythonSDK.ticketing"
+NAME = "MergePythonSDK"
 VERSION = "2.2.2"
 # To install the library, run the following
 #
@@ -28,16 +28,16 @@ REQUIRES = [
 setup(
     name=NAME,
     version=VERSION,
-    description="Merge Ticketing API",
+    description="Merge Unified API",
     author="Merge Team",
     author_email="hello@merge.dev",
     url="",
-    keywords=["OpenAPI", "OpenAPI-Generator", "Merge Ticketing API"],
+    keywords=["OpenAPI", "OpenAPI-Generator", "Merge Unified API"],
     python_requires=">=3.6",
     install_requires=REQUIRES,
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     long_description="""\
-    The unified API for building rich integrations with multiple Ticketing platforms.  # noqa: E501
+    The unified API for building rich integrations with multiple integration platforms.  # noqa: E501
     """
 )


### PR DESCRIPTION
# Version 2.2.2

- this is a re-issue of version 2.2.2 which originally had a typo in the published pip package name (setup.py)
- also adds a new field to accounting model's TrackingCategory

Tested with

```
    def testTrackingCategory(self):
        """Test TrackingCategory"""
        # FIXME: construct object with mandatory attributes with example values
        # model = TrackingCategory()  # noqa: E501

        """
        No test json responses were defined for TrackingCategory
        """
        raw_json = """{
            "id": "ecbe05ac-62a3-46c5-ab31-4b478b37d1b4",
            "remote_id": "948201",
            "name": "Marketing Department",
            "status": "ACTIVE",
            "category_type": "DEPARTMENT",
            "parent_category": "d25d609b-945f-4762-b55a-1c8fb220c43c",
            "remote_data": []
        }"""

        if raw_json is None:
            return

        response_mock = MagicMock()
        response_mock.data = raw_json

        deserialized = ApiClient().deserialize(response_mock, (TrackingCategory,), False)

        assert deserialized is not None
        assert deserialized.parent_category == "d25d609b-945f-4762-b55a-1c8fb220c43c"
```