### PR TITLE
Bump version to publish v2.2.5 bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.2.5
+
+## Date: 2023-01-31
+
+- Remove invalid `MergePythonSDK.shared.model.remote_user` import from `ats/api/users_api.py`
+
 # Version 2.2.4
 
 ## Date: 2022-11-2

--- a/MergePythonSDK/accounting/__init__.py
+++ b/MergePythonSDK/accounting/__init__.py
@@ -11,7 +11,7 @@
 """
 
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 # import ApiClient
 from MergePythonSDK.shared.api_client import ApiClient

--- a/MergePythonSDK/ats/__init__.py
+++ b/MergePythonSDK/ats/__init__.py
@@ -11,7 +11,7 @@
 """
 
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 # import ApiClient
 from MergePythonSDK.shared.api_client import ApiClient

--- a/MergePythonSDK/crm/__init__.py
+++ b/MergePythonSDK/crm/__init__.py
@@ -11,7 +11,7 @@
 """
 
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 # import ApiClient
 from MergePythonSDK.shared.api_client import ApiClient

--- a/MergePythonSDK/hris/__init__.py
+++ b/MergePythonSDK/hris/__init__.py
@@ -11,7 +11,7 @@
 """
 
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 # import ApiClient
 from MergePythonSDK.shared.api_client import ApiClient

--- a/MergePythonSDK/shared/__init__.py
+++ b/MergePythonSDK/shared/__init__.py
@@ -11,7 +11,7 @@
 """
 
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 # import ApiClient
 from MergePythonSDK.shared.api_client import ApiClient

--- a/MergePythonSDK/shared/api_client.py
+++ b/MergePythonSDK/shared/api_client.py
@@ -77,7 +77,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/2.2.4/python'
+        self.user_agent = 'OpenAPI-Generator/2.2.5/python'
 
     def __enter__(self):
         return self

--- a/MergePythonSDK/shared/configuration.py
+++ b/MergePythonSDK/shared/configuration.py
@@ -417,7 +417,7 @@ conf = MergePythonSDK.shared.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.0\n"\
-               "SDK Package Version: 2.2.4".\
+               "SDK Package Version: 2.2.5".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):

--- a/MergePythonSDK/ticketing/__init__.py
+++ b/MergePythonSDK/ticketing/__init__.py
@@ -11,7 +11,7 @@
 """
 
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 # import ApiClient
 from MergePythonSDK.shared.api_client import ApiClient

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "MergePythonSDK"
-VERSION = "2.2.4"
+VERSION = "2.2.5"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
Bump SDK version to publish https://github.com/merge-api/merge-sdk-python/pull/15

# Version 2.2.5

## Date: 2023-01-31

- Remove invalid `MergePythonSDK.shared.model.remote_user` import from `ats/api/users_api.py`